### PR TITLE
Add RatMenu DLL build with Self tab

### DIFF
--- a/RatMenu/CMakeLists.txt
+++ b/RatMenu/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.20)
+project(RatMenu VERSION 0.1 DESCRIPTION "Simple experimental menu")
+
+add_library(${PROJECT_NAME} MODULE
+    src/dllmain.cpp
+    src/SelfTab.cpp
+)
+
+find_package(OpenGL REQUIRED)
+find_package(glfw3 3.3 REQUIRED)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../cmake/imgui ${CMAKE_BINARY_DIR}/imgui)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    imgui
+    glfw
+    OpenGL::GL
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/include
+    ${CMAKE_CURRENT_LIST_DIR}/src
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "")
+

--- a/RatMenu/README.md
+++ b/RatMenu/README.md
@@ -1,0 +1,14 @@
+# RatMenu
+
+RatMenu is an experimental menu inspired by YimMenu v2. It uses Dear ImGui to present a rectangular window interface.  For now it only exposes a **Self** tab with a handful of options.
+
+## Building
+
+You will need a C++ compiler, CMake and the development packages for OpenGL and GLFW.  The project builds as a DLL so it can be injected into a game process.
+
+```bash
+cmake -S . -B build
+cmake --build build --config Release
+```
+
+The resulting library will be `RatMenu.dll` (or the platform equivalent).

--- a/RatMenu/include/SelfTab.hpp
+++ b/RatMenu/include/SelfTab.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace RatMenu {
+class SelfTab {
+public:
+    SelfTab();
+    void Draw();
+private:
+    std::map<std::string, bool> m_options;
+};
+}

--- a/RatMenu/src/SelfTab.cpp
+++ b/RatMenu/src/SelfTab.cpp
@@ -1,0 +1,23 @@
+#include "SelfTab.hpp"
+#include <imgui.h>
+
+namespace RatMenu {
+SelfTab::SelfTab()
+    : m_options{{"Godmode", false},
+                {"Super Jump", false},
+                {"Super Run", false},
+                {"Infinite Ammo", false},
+                {"No Ragdoll", false},
+                {"Noclip", false},
+                {"Heal", false}}
+{
+}
+
+void SelfTab::Draw()
+{
+    for (auto &opt : m_options)
+    {
+        ImGui::Checkbox(opt.first.c_str(), &opt.second);
+    }
+}
+} // namespace RatMenu

--- a/RatMenu/src/dllmain.cpp
+++ b/RatMenu/src/dllmain.cpp
@@ -1,0 +1,81 @@
+#include "SelfTab.hpp"
+#include <Windows.h>
+#include <imgui.h>
+#include <imgui_impl_glfw.h>
+#include <imgui_impl_opengl3.h>
+#include <GLFW/glfw3.h>
+
+namespace RatMenu {
+void RunMenu()
+{
+    if (!glfwInit())
+        return;
+    GLFWwindow* window = glfwCreateWindow(800, 600, "RatMenu", nullptr, nullptr);
+    if (!window)
+    {
+        glfwTerminate();
+        return;
+    }
+    glfwMakeContextCurrent(window);
+    glfwSwapInterval(1);
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGui_ImplGlfw_InitForOpenGL(window, true);
+    ImGui_ImplOpenGL3_Init("#version 130");
+
+    SelfTab selfTab;
+
+    while (!glfwWindowShouldClose(window))
+    {
+        glfwPollEvents();
+        ImGui_ImplOpenGL3_NewFrame();
+        ImGui_ImplGlfw_NewFrame();
+        ImGui::NewFrame();
+
+        ImGui::Begin("RatMenu", nullptr, ImGuiWindowFlags_AlwaysAutoResize);
+        if (ImGui::BeginTabBar("Tabs"))
+        {
+            if (ImGui::BeginTabItem("Self"))
+            {
+                selfTab.Draw();
+                ImGui::EndTabItem();
+            }
+            ImGui::EndTabBar();
+        }
+        ImGui::End();
+
+        ImGui::Render();
+        int display_w, display_h;
+        glfwGetFramebufferSize(window, &display_w, &display_h);
+        glViewport(0, 0, display_w, display_h);
+        glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+        glfwSwapBuffers(window);
+    }
+
+    ImGui_ImplOpenGL3_Shutdown();
+    ImGui_ImplGlfw_Shutdown();
+    ImGui::DestroyContext();
+    glfwDestroyWindow(window);
+    glfwTerminate();
+}
+}
+
+DWORD WINAPI MainThread(LPVOID module)
+{
+    RatMenu::RunMenu();
+    FreeLibraryAndExitThread(static_cast<HMODULE>(module), 0);
+    return 0;
+}
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID)
+{
+    if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+    {
+        DisableThreadLibraryCalls(hModule);
+        CreateThread(nullptr, 0, MainThread, hModule, 0, nullptr);
+    }
+    return TRUE;
+}


### PR DESCRIPTION
## Summary
- make RatMenu a shared library instead of an executable
- split menu code and add `SelfTab` class for options
- expose entry point via `DllMain`
- update build instructions in README

## Testing
- `cmake -S RatMenu -B RatMenu/build` *(fails: Could NOT find OpenGL)*

------
https://chatgpt.com/codex/tasks/task_e_6862d8309a9083298e44e97cd341b464